### PR TITLE
fix: address golangci-lint issues

### DIFF
--- a/integration-tests/testdata/programs/hcloud-ha-go/main.go
+++ b/integration-tests/testdata/programs/hcloud-ha-go/main.go
@@ -10,43 +10,41 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var (
-	clu = &cluster.Cluster{
-		PrivateNetwork:    "10.10.10.0/24",
-		PrivateSubnetwork: "10.10.10.0/25",
-		KubernetesVersion: "v1.31.0",
-		TalosImage: "ghcr.io/siderolabs/installer:v1.10.3",
-		Machines: []*cluster.Machine{
-			{
-				ID:         "controlplane-1",
-				Type:       "init",
-				ServerType: "cx22",
-				PrivateIP:  "10.10.10.5",
-			},
-			{
-				ID:         "controlplane-2",
-				Type:       string(talos.MachineTypesControlplane),
-				ServerType: "cx22",
-				PrivateIP:  "10.10.10.2",
-				Datacenter:   "fsn1-dc14",
-			},
-			{
-				ID:         "controlplane-3",
-				Type:       string(talos.MachineTypesControlplane),
-				ServerType: "cx22",
-				PrivateIP:  "10.10.10.10",
-				Datacenter:   "fsn1-dc14",
-			},
-			{
-				ID:         "worker-1",
-				Type:       "worker",
-				ServerType: "cx22",
-				PrivateIP:  "10.10.10.3",
-				Datacenter:   "fsn1-dc14",
-			},
+var clu = &cluster.Cluster{
+	PrivateNetwork:    "10.10.10.0/24",
+	PrivateSubnetwork: "10.10.10.0/25",
+	KubernetesVersion: "v1.31.0",
+	TalosImage:        "ghcr.io/siderolabs/installer:v1.10.3",
+	Machines: []*cluster.Machine{
+		{
+			ID:         "controlplane-1",
+			Type:       "init",
+			ServerType: "cx22",
+			PrivateIP:  "10.10.10.5",
 		},
-	}
-)
+		{
+			ID:         "controlplane-2",
+			Type:       string(talos.MachineTypesControlplane),
+			ServerType: "cx22",
+			PrivateIP:  "10.10.10.2",
+			Datacenter: "fsn1-dc14",
+		},
+		{
+			ID:         "controlplane-3",
+			Type:       string(talos.MachineTypesControlplane),
+			ServerType: "cx22",
+			PrivateIP:  "10.10.10.10",
+			Datacenter: "fsn1-dc14",
+		},
+		{
+			ID:         "worker-1",
+			Type:       "worker",
+			ServerType: "cx22",
+			PrivateIP:  "10.10.10.3",
+			Datacenter: "fsn1-dc14",
+		},
+	},
+}
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
@@ -109,7 +107,7 @@ func main() {
 				MachineId:     server.ID,
 				NodeIp:        server.IP,
 				MachineType:   talos.MachineTypes(m.Type),
-				TalosImage: pulumi.String(clu.TalosImage),
+				TalosImage:    pulumi.String(clu.TalosImage),
 				ConfigPatches: pulumi.String(rendered),
 			})
 		}

--- a/provider/pkg/provider/applier/yaml.go
+++ b/provider/pkg/provider/applier/yaml.go
@@ -148,7 +148,7 @@ func GuardUnmodifyK8sImages(img *K8SImages) Guard {
 	}
 }
 
-// ----- Internals -----
+// ----- Internals -----.
 func normalize(v any) any {
 	switch t := v.(type) {
 	case map[any]any:

--- a/provider/pkg/provider/applier/yaml_test.go
+++ b/provider/pkg/provider/applier/yaml_test.go
@@ -1,7 +1,6 @@
 package applier
 
 import (
-	//"strings"
 	"fmt"
 	"strings"
 	"testing"

--- a/provider/pkg/provider/cluster.go
+++ b/provider/pkg/provider/cluster.go
@@ -60,7 +60,6 @@ func GenerateDefaultInstallerImage() string {
 func cluster(ctx *pulumi.Context, c *Cluster, name string,
 	args *ClusterArgs, inputs provider.ConstructInputs, opts ...pulumi.ResourceOption,
 ) (*provider.ConstructResult, error) {
-	//runtime.Breakpoint()
 	// Blit the inputs onto the arguments struct.
 	if err := inputs.CopyTo(args); err != nil {
 		return nil, errors.Wrap(err, "setting args")


### PR DESCRIPTION
## Summary
- rely on generated provider schema and remove unused comments
- fix comment formatting in provider package
- format hcloud HA test program

## Testing
- `golangci-lint run -v ./...`
- `(cd provider && go test ./...)`
- `(cd provider && golangci-lint run -v ./...)`
- `(cd sdk && golangci-lint run -v ./...)`
- `(cd integration-tests && golangci-lint run -v ./...)`
- `(cd integration-tests/testdata/programs/hcloud-ha-go && golangci-lint run -v ./...)`
- `(cd integration-tests/testdata/programs/hcloud-go && golangci-lint run -v ./...)` *(fails: could not load export data)*
- `(cd sdk/python && golangci-lint run ./...)` *(fails: no go files)*


------
https://chatgpt.com/codex/tasks/task_e_68b42e234810832fbdb7140ce67af0c5