### PR TITLE
chore(dev): update workbench image

### DIFF
--- a/deploy/develop/base/develop.yaml
+++ b/deploy/develop/base/develop.yaml
@@ -24,7 +24,7 @@ spec:
   # ---- Native sidecar (restartable init container) ----
   initContainers:
     - name: plugin
-      image: ghcr.io/spigell/pulumi-talos-cluster-workbench:3.192.0-1ede2f
+      image: &workbench-image ghcr.io/spigell/pulumi-talos-cluster-workbench:3.193.0-de755f
       restartPolicy: Always
       workingDir: /projects
       command:
@@ -84,7 +84,7 @@ spec:
   # ---- Primary application container ----
   containers:
     - name: workbench
-      image: ghcr.io/spigell/pulumi-talos-cluster-workbench:3.192.0-1ede2f
+      image: *workbench-image
       workingDir: /projects
       command:
         - /bin/bash


### PR DESCRIPTION
## Summary
- update dev workbench image to `3.193.0-de755f`
- use YAML anchor to reference the image tag from a single place

## Testing
- `kubectl version --client`
- `kubectl kustomize deploy/develop/base | rg -n "image:"`
- `kubectl kustomize deploy/develop/overrides | rg -n "image:"`
- `make lint` *(fails: typecheck: pulumiSchema undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68bd340ca2f0832f94cb8527d19f36a5