### PR TITLE
Verify etcd cluster health before upgrades

### DIFF
--- a/provider/pkg/provider/apply.go
+++ b/provider/pkg/provider/apply.go
@@ -66,6 +66,8 @@ func apply(ctx *pulumi.Context, a *Apply, name string,
 
 		init := ma[tmachine.TypeInit.String()]
 
+		cp := ma[tmachine.TypeControlPlane.String()]
+
 		if len(init) == 0 {
 			return creds.ToStringMapOutput(), fmt.Errorf("a init node must exist")
 		}
@@ -80,11 +82,15 @@ func apply(ctx *pulumi.Context, a *Apply, name string,
 			IP:   i.NodeIP,
 		}
 
+		app.WithEtcdMembersCount(1)
+
 		inited, err := app.Init(i)
 		if err != nil {
 			return creds.ToStringMapOutput(), err
 		}
-		cp := ma[tmachine.TypeControlPlane.String()]
+
+		app.WithEtcdMembersCount(len(cp) + 1)
+
 		controlplanesReady := inited
 
 		for _, m := range cp {


### PR DESCRIPTION
## Summary
- check etcd health via talosctl before running CLI upgrades
- track expected etcd members and configure in Apply

## Testing
- `make unit_tests`


------
https://chatgpt.com/codex/tasks/task_e_68bd43d26c64832f86e00b25387d32cf