### PR TITLE
docs: narrow requirements list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,23 @@
 
 `pulumi-talos-cluster` is a Pulumi component designed to simplify the creation and management of Talos clusters. This component abstracts the complexities of setting up and managing Talos-based Kubernetes clusters, allowing for streamlined deployment and configuration.
 
-This component can be used for bare-metal and cloud installation. The direct access to apid in nodes is required.
+This component can be used for bare-metal and cloud installations. Direct access to `apid` on nodes is required.
 
-*Note: This project is in active development, and not everything is completed.*
+*Note: This project is in active development, and not all features are complete.*
+
+## Requirements
+
+Only Linux is supported as the runner operating system. The following tools must be available:
+
+- `bash`
+- `printf`
+- `talosctl`
+
+## Quick Start
+
+1. Install `bash`, `printf`, and `talosctl` on a Linux machine.
+2. Clone this repository.
+3. Run an example program, such as those under `integration-tests/testdata`, using `pulumi up`. The provider plugin installs automatically.
 
 ## Motivation
 
@@ -12,18 +26,17 @@ The official Terraform (and therefore Pulumi) provider for Talos has certain lim
 
 
 ## Development
-### GO
-*Note: It is recommended to use Pulumi local storage for development, as using the Pulumi service or self-hosted S3 storage can impact the speed of deployments.*
+### Go
+*Note: It is recommended to use Pulumi's local storage for development, as using the Pulumi service or self-hosted S3 storage can slow down deployments.*
 
-For component building:
+To build the component:
 ```
-$ make build && make install_provider # It generates all SDKs and build providers
+$ make build && make install_provider # This generates all SDKs and builds the provider
 $ export PATH=$PATH:~/go/bin
 ```
 
-### Prepare for releasing
-To build the provider and all SDKs (Go, Node.js, Python, .NET) in one step.
-Set the desired version explicitly, for example `v0.7.0`:
+### Preparing for release
+To build the provider and all SDKs (Go, Node.js, Python, and .NET) in one step, set the desired version explicitly (for example, `v0.7.0`):
 
 ```bash
 VERSION=v0.7.0 make build
@@ -38,8 +51,14 @@ git commit -m 'release'
 Refer to the `integration-tests/testdata` directory for sample Pulumi programs using the `pulumi-talos-cluster` component.
  
 ## Roadmap
-The following features and improvements are planned for future releases:
-- [x] **Kubernetes Version Configuration**: Allow setting the Kubernetes version directly via CLI
+
+### Current focus
+- Refactor tests.
+- Add more cloud providers to tests.
+- Include all supported languages in tests.
+
+### Planned enhancements
+- [x] **Kubernetes Version Configuration**: Allow setting the Kubernetes version directly via the CLI.
 - [ ] **Tests and Continuous Integration**: Implement tests and CI/CD pipelines to ensure code quality and stability.
 - [ ] **Multi-language Examples**: Provide usage examples in four languages (TypeScript, Python, Go, and .NET).
 - [ ] **Comprehensive Documentation**: Enhance documentation with detailed setup, customization, and troubleshooting guides.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,10 +4,11 @@ This directory contains Kustomize configurations for running the `pulumi-talos-c
 
 ## Pod Contents
 The workbench pod includes two containers:
-- `plugin` — an init container that fetches the repository, builds the provider plugin, and starts a Delve debugger.
-- `workbench` — the main container with Pulumi, Go, Talos and other development tools.
+- `plugin`—an init container that fetches the repository, builds the provider plugin, and starts a Delve debugger.
+- `workbench`—the main container with Pulumi, Go, Talos, and other development tools.
 
 ## Prerequisites
+- `kubectl` installed locally.
 - A Kubernetes cluster **with user namespace support**.
   - On clusters without user namespaces, you must enable `hostUsers` in the Pod spec. An example patch is provided in [`develop/overrides/patch-nfs-and-user.yaml`](develop/overrides/patch-nfs-and-user.yaml).
 
@@ -18,7 +19,7 @@ To deploy using the default configuration (user namespace supported):
 kubectl apply -k develop/base
 ```
 
-For clusters without user namespace support, apply the overrides (enables `hostUsers` and additional configuration):
+For clusters without user namespace support, apply the overrides (enabling `hostUsers` and additional configuration):
 
 ```bash
 kubectl apply -k develop/overrides
@@ -26,5 +27,4 @@ kubectl apply -k develop/overrides
 
 The `overrides` kustomization is provided as an example; adjust it to match your environment or create your own patches.
 
-This will create the `pulumi-talos-cluster-workbench` pod in the `pulumi-talos-cluster-dev` namespace with all required development tools.
-
+This creates the `pulumi-talos-cluster-workbench` pod in the `pulumi-talos-cluster-dev` namespace with all required development tools.

--- a/integration-tests/packer/README.md
+++ b/integration-tests/packer/README.md
@@ -1,4 +1,7 @@
-## Run to create a new version
+## Creating a new version
+
+Run the following command to build a new image version:
+
 ```
 go run ./run-packer.go -var=talos_version=v1.10.3 -template ./hcloud-talos.pkr.hcl
 ```


### PR DESCRIPTION
## Summary
- limit requirements to talosctl, bash, and printf
- streamline quick start by removing provider build step and noting the plugin installs automatically

## Testing
- `go test ./...` *(fails: pattern ./...: directory prefix . does not contain modules listed in go.work or their selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c56b1a381c832fb377be120b953a0b