### PR TITLE
refactor: add cloud provider interface

### DIFF
--- a/integration-tests/pkg/cloud/provider.go
+++ b/integration-tests/pkg/cloud/provider.go
@@ -1,0 +1,35 @@
+package cloud
+
+import "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+// Provider defines an interface for cloud providers that can provision
+// networks and servers for the integration tests.
+type Provider interface {
+	// Servers returns the list of servers that will be created by the provider.
+	Servers() []Server
+	// Up provisions the infrastructure in the cloud provider.
+	Up() (*Deployed, error)
+}
+
+// Server represents a machine instance created by a cloud provider.
+type Server interface {
+	// ID returns the identifier for the server.
+	ID() string
+	// IP returns the public IPv4 address assigned to the server.
+	IP() pulumi.StringOutput
+	// WithUserdata sets the user data for the server and returns the updated
+	// server instance.
+	WithUserdata(userdata pulumi.StringOutput) Server
+}
+
+// Network abstracts a private network created by the cloud provider.
+type Network interface {
+	// ID returns the identifier for the network resource.
+	ID() pulumi.StringOutput
+}
+
+// Deployed represents resources created by a Provider.
+type Deployed struct {
+	Servers []Server
+	Deps    []pulumi.Resource
+}


### PR DESCRIPTION
## Summary
- introduce generic cloud Provider and Server interfaces
- migrate Hetzner implementation under cloud/hcloud
- update test programs to use cloud.Provider instead of Hetzner types

## Testing
- `go test ./integration-tests/pkg/cloud/...`
- `go test ./integration-tests/testdata/programs/hcloud-go`
- `go test ./integration-tests/testdata/programs/hcloud-ha-go`


------
https://chatgpt.com/codex/tasks/task_e_68c5a96c6370832f81f719ec7d15173f