### PR TITLE
feat(tests): add reusable talos package

### DIFF
--- a/integration-tests/pkg/cluster/cluster.go
+++ b/integration-tests/pkg/cluster/cluster.go
@@ -9,12 +9,13 @@ type Cluster struct {
 }
 
 type Machine struct {
-	ID                  string `yaml:"id"`
-	Type                string `yaml:"type"`
-	ServerType          string `yaml:"serverType"`
-	Platform            string `yaml:"platform"`
-	TalosInitialVersion string `yaml:"talosInitialVersion"`
-	TalosImage          string `yaml:"talosImage"`
-	PrivateIP           string `yaml:"privateIP"`
-	Datacenter          string `yaml:"datacenter"`
+	ID                  string   `yaml:"id"`
+	Type                string   `yaml:"type"`
+	ServerType          string   `yaml:"serverType"`
+	Platform            string   `yaml:"platform"`
+	TalosInitialVersion string   `yaml:"talosInitialVersion"`
+	TalosImage          string   `yaml:"talosImage"`
+	PrivateIP           string   `yaml:"privateIP"`
+	Datacenter          string   `yaml:"datacenter"`
+	ConfigPatches       []string `yaml:"configPatches"`
 }

--- a/integration-tests/pkg/cluster/spec.py
+++ b/integration-tests/pkg/cluster/spec.py
@@ -13,6 +13,7 @@ class Machine:
     talosImage: str
     privateIP: str
     datacenter: str
+    configPatches: List[str]
 
 
 @dataclass
@@ -27,7 +28,13 @@ class Cluster:
 def load(path: str) -> Cluster:
     with open(path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
-    machines = [Machine(**m) for m in data.get("machines", [])]
+    machines = [
+        Machine(
+            configPatches=m.get("configPatches", []),
+            **{k: v for k, v in m.items() if k != "configPatches"}
+        )
+        for m in data.get("machines", [])
+    ]
     return Cluster(
         name=data.get("name", ""),
         privateNetwork=data.get("privateNetwork", ""),

--- a/integration-tests/pkg/cluster/spec.ts
+++ b/integration-tests/pkg/cluster/spec.ts
@@ -10,6 +10,7 @@ export interface Machine {
   talosImage: string;
   privateIP: string;
   datacenter: string;
+  configPatches: string[];
 }
 
 export interface Cluster {

--- a/integration-tests/testdata/programs/hcloud-go/main.go
+++ b/integration-tests/testdata/programs/hcloud-go/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spigell/pulumi-talos-cluster/integration-tests/pkg/cloud"
 	hcloud "github.com/spigell/pulumi-talos-cluster/integration-tests/pkg/cloud/hcloud"
 	"github.com/spigell/pulumi-talos-cluster/integration-tests/pkg/cluster"
+	talospkg "github.com/spigell/pulumi-talos-cluster/integration-tests/pkg/talos"
 )
 
 var (
@@ -55,7 +56,7 @@ func main() {
 
 		servers := provider.Servers()
 
-		talosClu, err := NewTalosCluster(ctx, clu, servers)
+		talosClu, err := talospkg.NewCluster(ctx, clu, servers)
 		if err != nil {
 			return err
 		}

--- a/integration-tests/testdata/programs/hcloud-js/hetzner.ts
+++ b/integration-tests/testdata/programs/hcloud-js/hetzner.ts
@@ -1,79 +1,89 @@
 import * as hcloud from "@pulumi/hcloud";
 import * as pulumi from "@pulumi/pulumi";
-import * as forge from 'node-forge';
-import {Cluster, DeployedServer} from './types'
+import * as forge from "node-forge";
+import { Cluster, DeployedServer } from "./types";
 
-const defaultTalosInitialVersion = 'v1.10.3'
-const arch = 'arm'
-const variant = 'metal'
+const defaultTalosInitialVersion = "v1.10.3";
+const arch = "arm";
+const variant = "metal";
 
-export function Hetzner (cluster: Cluster): DeployedServer[] {
-    const sshKey = new hcloud.SshKey("ssh", {
-        publicKey: generateSSHKey().then(keys => keys.publicKey),
-    }, {ignoreChanges: ["publicKey"]})
+export function Hetzner(cluster: Cluster): DeployedServer[] {
+  const sshKey = new hcloud.SshKey(
+    "ssh",
+    {
+      publicKey: generateSSHKey().then((keys) => keys.publicKey),
+    },
+    { ignoreChanges: ["publicKey"] },
+  );
 
-    // Create the private network
-    const network = new hcloud.Network("private-network", {
-        name: pulumi.interpolate`private-network-${cluster.name}`,
-        ipRange: cluster.privateNetwork,
+  // Create the private network
+  const network = new hcloud.Network("private-network", {
+    name: pulumi.interpolate`private-network-${cluster.name}`,
+    ipRange: cluster.privateNetwork,
+  });
+
+  // Convert network ID to integer
+  const convertedNetID = network.id.apply((id) => parseInt(id, 10));
+
+  // Add a subnet to the private network
+  new hcloud.NetworkSubnet("private-subnet", {
+    networkId: convertedNetID,
+    type: "server",
+    networkZone: "eu-central", // Adjust based on your preferred region
+    ipRange: cluster.privateSubnetwork,
+  });
+
+  const selector = `os=talos,version=${defaultTalosInitialVersion},variant=${variant},arch=${arch}`;
+  const image = hcloud.getImage({
+    withSelector: selector,
+    withArchitecture: arch,
+  });
+
+  const deployed: DeployedServer[] = [];
+
+  for (const machine of cluster.machines) {
+    // Define the server
+    const server = new hcloud.Server(
+      machine.id,
+      {
+        name: machine.id,
+        serverType: machine.serverType,
+        image: image.then((v) => `${v.id}`),
+        location: "nbg1",
+        sshKeys: [sshKey.id],
+        networks: [
+          {
+            networkId: convertedNetID,
+            ip: machine.privateIP,
+          },
+        ],
+      },
+      { ignoreChanges: ["sshKeys"] },
+    );
+
+    deployed.push({
+      id: machine.id,
+      ip: server.ipv4Address,
     });
+  }
 
-    // Convert network ID to integer
-    const convertedNetID = network.id.apply((id) => parseInt(id, 10));
-
-    // Add a subnet to the private network
-    new hcloud.NetworkSubnet("private-subnet", {
-        networkId: convertedNetID,
-        type: "server",
-        networkZone: "eu-central", // Adjust based on your preferred region
-        ipRange: cluster.PrivateSubnetwork,
-    });
-
-    const selector = `os=talos,version=${defaultTalosInitialVersion},variant=${variant},arch=${arch}`
-    const image = hcloud.getImage({
-        withSelector: selector,
-        withArchitecture: arch
-    })
-
-    const deployed: DeployedServer[] = [];
-
-    for (const machine of cluster.machines) {
-        // Define the server
-        const server = new hcloud.Server(machine.id, {
-            name: machine.id,
-            serverType: machine.serverType,
-            image: image.then(v => `${v.id}`),
-            location: "nbg1",
-            sshKeys: [sshKey.id],
-            networks: [{
-                networkId: convertedNetID,
-                ip: machine.privateIP,
-            }],
-        }, {ignoreChanges: ['sshKeys']});
-
-        deployed.push({
-            id: machine.id,
-            ip: server.ipv4Address,
-        });
-    }
-
-    return deployed;
+  return deployed;
 }
 
 async function generateSSHKey(): Promise<{ publicKey: string }> {
-    return new Promise((resolve, reject) => {
-        try {
-            // Generate an RSA key pair
-            const keypair = forge.pki.rsa.generateKeyPair(2048);
+  return new Promise((resolve, reject) => {
+    try {
+      // Generate an RSA key pair
+      const keypair = forge.pki.rsa.generateKeyPair(2048);
 
-            // Convert to PEM format
-            const publicKeyForge = forge.ssh.publicKeyToOpenSSH(keypair.publicKey);
+      // Convert to PEM format
+      const publicKeyForge = forge.ssh.publicKeyToOpenSSH(keypair.publicKey);
 
-            const publicKey = `${publicKeyForge}`;
+      const publicKey = `${publicKeyForge}`;
 
-            resolve({ publicKey });
-        } catch (error) {
-            reject(`Error generating SSH keys: ${error}`);
-        }
-    });
+      resolve({ publicKey });
+    } catch (error) {
+      reject(`Error generating SSH keys: ${error}`);
+    }
+  });
 }

--- a/integration-tests/testdata/programs/hcloud-js/index.ts
+++ b/integration-tests/testdata/programs/hcloud-js/index.ts
@@ -1,50 +1,55 @@
 import * as pulumi from "@pulumi/pulumi";
-import * as talos from "@spigell/pulumi-talos-cluster"
-import {Cluster} from './types'
-import {Hetzner} from './hetzner'
+import * as talos from "@spigell/pulumi-talos-cluster";
+import { Cluster } from "./types";
+import { Hetzner } from "./hetzner";
 
 const cluster: Cluster = {
-	name: pulumi.getStack(),
-	kubernetesVersion: 'v1.34.0',
-	privateNetwork: '10.10.0.0/16',
-	PrivateSubnetwork: '10.10.10.0/25',
-	machines: [
-		{
-			id: 'controlplane-1',
-			type: talos.MachineTypes.Init,
-			serverType: 'cax21',
-			privateIP: '10.10.10.2'
-		}
-	]
-}
+  name: pulumi.getStack(),
+  kubernetesVersion: "v1.34.0",
+  privateNetwork: "10.10.0.0/16",
+  privateSubnetwork: "10.10.10.0/25",
+  machines: [
+    {
+      id: "controlplane-1",
+      type: talos.MachineTypes.Init,
+      serverType: "cax21",
+      privateIP: "10.10.10.2",
+      configPatches: [
+        JSON.stringify({
+          debug: true,
+          machine: {
+            network: {
+              hostname: "master-1",
+            },
+          },
+        }),
+      ],
+    },
+  ],
+};
 
-const servers = Hetzner(cluster)
-const machines: pulumi.Input<pulumi.Input<talos.types.input.ClusterMachinesArgs>[]> = []
+const servers = Hetzner(cluster);
+const machines: pulumi.Input<
+  pulumi.Input<talos.types.input.ClusterMachinesArgs>[]
+> = [];
 
-cluster.machines.forEach(v => machines.push({
-	machineId: v.id,
-	nodeIp: servers.find(m => v.id == m.id)?.ip as pulumi.Input<string>,
-	machineType: v.type,
-	configPatches: [JSON.stringify({
-			debug: true,
-			machine: {
-	            network: {
-	              hostname: "master-1",
-	            }
-            }
-        })
-	]
-}))
+cluster.machines.forEach((v) =>
+  machines.push({
+    machineId: v.id,
+    nodeIp: servers.find((m) => v.id == m.id)?.ip as pulumi.Input<string>,
+    machineType: v.type,
+    configPatches: v.configPatches,
+  }),
+);
 
 const clu = new talos.Cluster(cluster.name, {
-	kubernetesVersion: cluster.kubernetesVersion,
-	clusterEndpoint: pulumi.interpolate `https://${servers[0].ip}:6443`,
-	clusterName: cluster.name,
-	clusterMachines: machines,
-})
-
+  kubernetesVersion: cluster.kubernetesVersion,
+  clusterEndpoint: pulumi.interpolate`https://${servers[0].ip}:6443`,
+  clusterName: cluster.name,
+  clusterMachines: machines,
+});
 
 export const apply = new talos.Apply(cluster.name, {
-		clientConfiguration: clu.clientConfiguration,
-		applyMachines: clu.machines
-})
+  clientConfiguration: clu.clientConfiguration,
+  applyMachines: clu.machines,
+});

--- a/integration-tests/testdata/programs/hcloud-js/types.ts
+++ b/integration-tests/testdata/programs/hcloud-js/types.ts
@@ -1,22 +1,27 @@
-import * as talos from "@spigell/pulumi-talos-cluster"
+import * as talos from "@spigell/pulumi-talos-cluster";
 import * as pulumi from "@pulumi/pulumi";
 
 export type Cluster = {
-	name: string;
-	kubernetesVersion: string;
-	privateNetwork: string;
-	PrivateSubnetwork: string;
-	machines: ClusterMachine[];
-}
+  name: string;
+  kubernetesVersion: string;
+  privateNetwork: string;
+  privateSubnetwork: string;
+  machines: ClusterMachine[];
+};
 
 export type ClusterMachine = {
-	id: string
-	type: talos.MachineTypes
-	serverType: string
-	privateIP: string
-}
+  id: string;
+  type: talos.MachineTypes;
+  serverType: string;
+  privateIP: string;
+  talosImage?: string;
+  datacenter?: string;
+  platform?: string;
+  talosInitialVersion?: string;
+  configPatches?: string[];
+};
 
 export type DeployedServer = {
-	id: string
-	ip: pulumi.Output<string>
-}
+  id: string;
+  ip: pulumi.Output<string>;
+};


### PR DESCRIPTION
## Summary
- add talos package for integration tests to init and apply clusters
- extend cluster spec with config patches
- fix NodeJS sample to use new spec keys

## Testing
- `go test ./...` *(fails: Expected to find `pulumi` binary on $PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b73d8e8c832fbde180c97f59108a