### PR TITLE
refactor hcloud-go test to load cluster spec

### DIFF
--- a/integration-tests/testdata/programs/hcloud-go/cluster.yaml
+++ b/integration-tests/testdata/programs/hcloud-go/cluster.yaml
@@ -1,0 +1,19 @@
+name: ""
+kubernetesVersion: 1.32.0
+privateNetwork: 10.10.10.0/24
+privateSubnetwork: 10.10.10.0/25
+machines:
+  - id: controlplane-1
+    type: init
+    platform: hcloud
+    talosImage: ghcr.io/siderolabs/installer:v1.11.0
+    serverType: cx22
+    privateIP: 10.10.10.5
+    datacenter: fsn1-dc14
+  - id: worker-1
+    type: worker
+    platform: hcloud
+    talosImage: ghcr.io/siderolabs/installer:v1.11.0
+    serverType: cx22
+    privateIP: 10.10.10.3
+    datacenter: fsn1-dc14

--- a/integration-tests/testdata/programs/hcloud-go/main.go
+++ b/integration-tests/testdata/programs/hcloud-go/main.go
@@ -4,51 +4,19 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/spigell/pulumi-talos-cluster/integration-tests/pkg/cloud"
 	hcloud "github.com/spigell/pulumi-talos-cluster/integration-tests/pkg/cloud/hcloud"
 	"github.com/spigell/pulumi-talos-cluster/integration-tests/pkg/cluster"
 )
 
-var (
-	platform   = "hcloud"
-	talosImage = "ghcr.io/siderolabs/installer:v1.11.0"
-)
-
-var clu = &cluster.Cluster{
-	PrivateNetwork:    "10.10.10.0/24",
-	PrivateSubnetwork: "10.10.10.0/25",
-	KubernetesVersion: "1.32.0",
-	Machines: []*cluster.Machine{
-		{
-			ID:         "controlplane-1",
-			Type:       "init",
-			Platform:   platform,
-			TalosImage: talosImage,
-			ServerType: "cx22",
-			PrivateIP:  "10.10.10.5",
-			Datacenter: "fsn1-dc14",
-		},
-		{
-			ID:         "worker-1",
-			Type:       "worker",
-			Platform:   platform,
-			TalosImage: talosImage,
-			ServerType: "cx22",
-			PrivateIP:  "10.10.10.3",
-			Datacenter: "fsn1-dc14",
-		},
-	},
-}
-
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+		clu, err := cluster.Load("cluster.yaml")
+		if err != nil {
+			return err
+		}
 		clu.Name = ctx.Stack()
 
-		var (
-			provider cloud.Provider
-			err      error
-		)
-		provider, err = hcloud.NewWithIPS(ctx, clu)
+		provider, err := hcloud.NewWithIPS(ctx, clu)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- load hcloud Go test cluster settings from a new `cluster.yaml`
- use `stretchr/testify` assertions in integration test harness
- drop unused import in hcloud test program

## Testing
- `GOFLAGS="-mod=readonly" go test -run TestHcloudClusterGo -count=1 -timeout 1m` *(fails: Missing Hetzner Cloud API token)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b5724824832fb508a4100e364141