### PR TITLE
refactor: centralize hcloud cluster deploy

### DIFF
--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/pulumi/pulumi-hcloud/sdk v1.24.0
 	github.com/pulumi/pulumi/pkg/v3 v3.193.0
 	github.com/pulumi/pulumi/sdk/v3 v3.193.0
+	github.com/spigell/pulumi-talos-cluster/sdk v0.0.0-20250913135849-16db0cf29273
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.41.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -68,7 +69,6 @@ require (
 	github.com/edsrzf/mmap-go v1.2.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
@@ -108,7 +108,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -382,6 +382,8 @@ github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spigell/pulumi-talos-cluster/sdk v0.0.0-20250913135849-16db0cf29273 h1:+thht/++iDLTDP+k6AvmcSTVIuVI1L+/QKDUgnTL65s=
+github.com/spigell/pulumi-talos-cluster/sdk v0.0.0-20250913135849-16db0cf29273/go.mod h1:4kI5am564q1H3OdozAMs9EqE7R8xtvxUeGAAS3Bf1lA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/integration-tests/pkg/cluster/cluster.go
+++ b/integration-tests/pkg/cluster/cluster.go
@@ -18,4 +18,5 @@ type Machine struct {
 	PrivateIP           string   `yaml:"privateIP"`
 	Datacenter          string   `yaml:"datacenter"`
 	ConfigPatches       []string `yaml:"configPatches"`
+	Userdata            string   `yaml:"userdata"`
 }

--- a/integration-tests/pkg/cluster/deploy.go
+++ b/integration-tests/pkg/cluster/deploy.go
@@ -1,0 +1,70 @@
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/spigell/pulumi-talos-cluster/integration-tests/pkg/cloud"
+	talospkg "github.com/spigell/pulumi-talos-cluster/integration-tests/pkg/talos"
+)
+
+// Deploy provisions servers with the given provider and boots a Talos cluster.
+// If patchUserdata is true, Talos-generated configuration is set as the userdata
+// for each server (unless overridden in the machine spec).
+func Deploy(ctx *pulumi.Context, clu *Cluster, provider cloud.Provider, patchUserdata bool) (*talospkg.Cluster, *talospkg.Applied, error) {
+	servers := provider.Servers()
+
+	spec := &talospkg.Spec{Name: clu.Name, Machines: make([]talospkg.MachineSpec, len(clu.Machines))}
+	for i, m := range clu.Machines {
+		spec.Machines[i] = talospkg.MachineSpec{
+			ID:            m.ID,
+			Type:          m.Type,
+			TalosImage:    m.TalosImage,
+			ConfigPatches: m.ConfigPatches,
+		}
+	}
+
+	talosClu, err := talospkg.NewCluster(ctx, spec, servers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if patchUserdata {
+		for _, s := range servers {
+			m := machineByID(clu, s.ID())
+			var userdata pulumi.StringInput
+			if m != nil && m.Userdata != "" {
+				userdata = pulumi.String(m.Userdata)
+			} else {
+				userdata = talosClu.Cluster.GeneratedConfigurations.MapIndex(
+					pulumi.String(s.ID()),
+				).ToStringOutput()
+			}
+			s.WithUserdata(userdata.ToStringOutput().ApplyT(func(v string) string {
+				ctx.Log.Debug(fmt.Sprintf("set userdata for server %s: \n\n%s\n\n===", s.ID(), v), nil)
+				return v
+			}).(pulumi.StringOutput))
+		}
+	}
+
+	deployed, err := provider.Up()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	applied, err := talosClu.Apply(deployed.Deps)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return talosClu, applied, nil
+}
+
+func machineByID(c *Cluster, id string) *Machine {
+	for _, m := range c.Machines {
+		if m.ID == id {
+			return m
+		}
+	}
+	return nil
+}

--- a/integration-tests/pkg/cluster/spec.py
+++ b/integration-tests/pkg/cluster/spec.py
@@ -14,6 +14,7 @@ class Machine:
     privateIP: str
     datacenter: str
     configPatches: List[str]
+    userdata: str
 
 
 @dataclass
@@ -31,7 +32,8 @@ def load(path: str) -> Cluster:
     machines = [
         Machine(
             configPatches=m.get("configPatches", []),
-            **{k: v for k, v in m.items() if k != "configPatches"}
+            userdata=m.get("userdata", ""),
+            **{k: v for k, v in m.items() if k not in ("configPatches", "userdata")}
         )
         for m in data.get("machines", [])
     ]

--- a/integration-tests/pkg/cluster/spec.ts
+++ b/integration-tests/pkg/cluster/spec.ts
@@ -11,6 +11,7 @@ export interface Machine {
   privateIP: string;
   datacenter: string;
   configPatches: string[];
+  userdata: string;
 }
 
 export interface Cluster {

--- a/integration-tests/testdata/programs/hcloud-js/types.ts
+++ b/integration-tests/testdata/programs/hcloud-js/types.ts
@@ -19,6 +19,7 @@ export type ClusterMachine = {
   platform?: string;
   talosInitialVersion?: string;
   configPatches?: string[];
+  userdata?: string;
 };
 
 export type DeployedServer = {


### PR DESCRIPTION
## Summary
- expose reusable Deploy helper in cluster package
- reintroduce Talos utilities without merging into cluster
- update hcloud Go examples to leverage Deploy with optional userdata patching

## Testing
- `go build -v ./integration-tests/testdata/programs/hcloud-go`
- `go build -v ./integration-tests/testdata/programs/hcloud-ha-go`
- `go test ./integration-tests/...` *(no output; aborted)*
- `cd integration-tests/testdata/programs/hcloud-js && npm install`

------
https://chatgpt.com/codex/tasks/task_e_68c68a7b1210832fbd0c619a9f2b0854