### PR TITLE
Refactor hcloud cluster specs using YAML anchors

### DIFF
--- a/integration-tests/testdata/programs/hcloud-ha-go/cluster.yaml
+++ b/integration-tests/testdata/programs/hcloud-ha-go/cluster.yaml
@@ -13,46 +13,42 @@ patches:
       etcd:
         advertisedSubnets:
           - 10.10.10.0/24
-  timeEnabled: &timeEnabled |
-    machine:
-      time:
-        disabled: false
-  cloudflared: &cloudflared |
-    apiVersion: v1alpha1
-    kind: ExtensionServiceConfig
-    name: cloudflared
-    environment:
-      - TUNNEL_TOKEN=CHANGE_ME_AGAIN
-      - TUNNEL_METRICS=localhost:2001
-      - TUNNEL_EDGE_IP_VERSION=auto
   controlplane: &controlplanePatches
     - *machineBase
     - *controlplaneCluster
-    - *timeEnabled
-    - *cloudflared
   worker: &workerPatches
     - *machineBase
-    - *timeEnabled
-    - *cloudflared
 
 machineDefaults: &machineDefaults
-  platform: hcloud
-  talosImage: ghcr.io/siderolabs/installer:v1.11.0
+  platform: metal
+  talosImage: ghcr.io/siderolabs/installer:v1.10.6
   serverType: cx22
-  datacenter: fsn1-dc14
 
-name: hcloud-go
-kubernetesVersion: 1.32.0
+controlplaneDefaults: &controlplaneDefaults
+  <<: *machineDefaults
+  type: controlplane
+  configPatches: *controlplanePatches
+
+workerDefaults: &workerDefaults
+  <<: *machineDefaults
+  type: worker
+  configPatches: *workerPatches
+
+name: hcloud-ha-go
+kubernetesVersion: v1.31.0
 privateNetwork: 10.10.10.0/24
 privateSubnetwork: 10.10.10.0/25
 machines:
-  - <<: *machineDefaults
+  - <<: *controlplaneDefaults
     id: controlplane-1
     type: init
     privateIP: 10.10.10.5
-    configPatches: *controlplanePatches
-  - <<: *machineDefaults
+  - <<: *controlplaneDefaults
+    id: controlplane-2
+    privateIP: 10.10.10.2
+  - <<: *controlplaneDefaults
+    id: controlplane-3
+    privateIP: 10.10.10.10
+  - <<: *workerDefaults
     id: worker-1
-    type: worker
     privateIP: 10.10.10.3
-    configPatches: *workerPatches

--- a/integration-tests/testdata/programs/hcloud-ha-go/main.go
+++ b/integration-tests/testdata/programs/hcloud-ha-go/main.go
@@ -4,107 +4,30 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	hcloud "github.com/spigell/pulumi-talos-cluster/integration-tests/pkg/cloud/hcloud"
 	"github.com/spigell/pulumi-talos-cluster/integration-tests/pkg/cluster"
-	talos "github.com/spigell/pulumi-talos-cluster/sdk/go/talos-cluster"
-	"gopkg.in/yaml.v3"
 )
-
-var (
-	platform   = "metal"
-	talosImage = "ghcr.io/siderolabs/installer:v1.10.6"
-)
-
-var clu = &cluster.Cluster{
-	PrivateNetwork:    "10.10.10.0/24",
-	PrivateSubnetwork: "10.10.10.0/25",
-	KubernetesVersion: "v1.31.0",
-	Machines: []*cluster.Machine{
-		{
-			ID:         "controlplane-1",
-			Type:       "init",
-			TalosImage: talosImage,
-			Platform:   platform,
-			ServerType: "cx22",
-			PrivateIP:  "10.10.10.5",
-		},
-		{
-			ID:         "controlplane-2",
-			Type:       string(talos.MachineTypesControlplane),
-			Platform:   platform,
-			TalosImage: talosImage,
-
-			ServerType: "cx22",
-			PrivateIP:  "10.10.10.2",
-			//	Datacenter: "fsn1-dc14",
-		},
-		{
-			ID:         "controlplane-3",
-			Type:       string(talos.MachineTypesControlplane),
-			ServerType: "cx22",
-			Platform:   platform,
-			TalosImage: talosImage,
-			PrivateIP:  "10.10.10.10",
-			//	Datacenter: "fsn1-dc14",
-		},
-		{
-			ID:         "worker-1",
-			Type:       "worker",
-			Platform:   platform,
-			TalosImage: talosImage,
-			ServerType: "cx22",
-			PrivateIP:  "10.10.10.3",
-			//	Datacenter: "fsn1-dc14",
-		},
-	},
-}
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		clu.Name = ctx.Stack()
-
-		for _, m := range clu.Machines {
-			patches := map[string]any{
-				"debug": false,
-				"machine": map[string]any{
-					"kubelet": map[string]any{
-						"nodeIP": map[string]any{
-							"validSubnets": []string{
-								clu.PrivateNetwork,
-							},
-						},
-					},
-					"time": map[string]any{
-						"disabled": true,
-					},
-				},
-			}
-
-			if m.Type == "controlplane" || m.Type == "init" {
-				patches["cluster"] = map[string]any{
-					"etcd": map[string]any{
-						"advertisedSubnets": []string{
-							clu.PrivateNetwork,
-						},
-					},
-				}
-			}
-
-			rendered, _ := yaml.Marshal(patches)
-			m.ConfigPatches = []string{string(rendered)}
+		clu, err := cluster.Load("cluster.yaml")
+		if err != nil {
+			return err
 		}
+
+		clu.Name = ctx.Stack()
 
 		provider, err := hcloud.NewWithIPS(ctx, clu)
 		if err != nil {
 			return err
 		}
 
-		talosClu, applied, err := cluster.Deploy(ctx, clu, provider, true)
+		deployed, err := cluster.Deploy(ctx, provider, clu)
 		if err != nil {
 			return err
 		}
 
-		ctx.Export("clusterMachineConfigs", talosClu.Cluster.GeneratedConfigurations)
-		ctx.Export("kubeconfig", applied.Kubeconfig)
-		ctx.Export("talosconfig", applied.Talosconfig)
+		ctx.Export("clusterMachineConfigs", deployed.ClusterMachines)
+		ctx.Export("kubeconfig", deployed.Credentials.Kubeconfig)
+		ctx.Export("talosconfig", deployed.Credentials.Talosconfig)
 
 		return nil
 	})


### PR DESCRIPTION
## Summary
- refactor the hcloud-go cluster specification to reuse machine and patch blocks through YAML anchors
- add an anchored cluster.yaml for the hcloud-ha-go example and load it from disk instead of hardcoding the cluster structure

## Testing
- `cd integration-tests/testdata/programs/hcloud-ha-go && go build ./...`
- `cd integration-tests/testdata/programs/hcloud-go && go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c984ccd3cc832f86f07c6e77d64e98