### PR TITLE
Refactor hcloud integration spec options

### DIFF
--- a/integration-tests/pkg/cluster/cluster.go
+++ b/integration-tests/pkg/cluster/cluster.go
@@ -9,14 +9,18 @@ type Cluster struct {
 }
 
 type Machine struct {
-	ID                  string   `yaml:"id"`
-	Type                string   `yaml:"type"`
-	ServerType          string   `yaml:"serverType"`
-	Platform            string   `yaml:"platform"`
-	TalosInitialVersion string   `yaml:"talosInitialVersion"`
-	TalosImage          string   `yaml:"talosImage"`
-	PrivateIP           string   `yaml:"privateIP"`
-	Datacenter          string   `yaml:"datacenter"`
-	ConfigPatches       []string `yaml:"configPatches"`
-	ApplyConfigViaUserdata            bool   `yaml:"apply-config-via-userdata"`
+	ID                     string         `yaml:"id"`
+	Type                   string         `yaml:"type"`
+	Platform               string         `yaml:"platform"`
+	TalosInitialVersion    string         `yaml:"talosInitialVersion"`
+	TalosImage             string         `yaml:"talosImage"`
+	PrivateIP              string         `yaml:"privateIP"`
+	ConfigPatches          []string       `yaml:"configPatches"`
+	ApplyConfigViaUserdata bool           `yaml:"apply-config-via-userdata"`
+	Hcloud                 *HcloudMachine `yaml:"hcloud"`
+}
+
+type HcloudMachine struct {
+	ServerType string `yaml:"serverType"`
+	Datacenter string `yaml:"datacenter"`
 }

--- a/integration-tests/pkg/cluster/spec.py
+++ b/integration-tests/pkg/cluster/spec.py
@@ -1,20 +1,25 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 import yaml
+
+
+@dataclass
+class HcloudMachine:
+    serverType: str
+    datacenter: Optional[str] = None
 
 
 @dataclass
 class Machine:
     id: str
     type: str
-    serverType: str
     platform: str
     talosInitialVersion: str
     talosImage: str
     privateIP: str
-    datacenter: str
     configPatches: List[str]
     userdata: str
+    hcloud: Optional[HcloudMachine] = None
 
 
 @dataclass
@@ -33,7 +38,12 @@ def load(path: str) -> Cluster:
         Machine(
             configPatches=m.get("configPatches", []),
             userdata=m.get("userdata", ""),
-            **{k: v for k, v in m.items() if k not in ("configPatches", "userdata")}
+            hcloud=HcloudMachine(**m["hcloud"]) if m.get("hcloud") else None,
+            **{
+                k: v
+                for k, v in m.items()
+                if k not in ("configPatches", "userdata", "hcloud")
+            }
         )
         for m in data.get("machines", [])
     ]

--- a/integration-tests/pkg/cluster/spec.ts
+++ b/integration-tests/pkg/cluster/spec.ts
@@ -1,17 +1,21 @@
 import { readFileSync } from "fs";
 import { parse } from "yaml";
 
+export interface HcloudMachine {
+  serverType: string;
+  datacenter?: string;
+}
+
 export interface Machine {
   id: string;
   type: string;
-  serverType: string;
   platform: string;
   talosInitialVersion: string;
   talosImage: string;
   privateIP: string;
-  datacenter: string;
   configPatches: string[];
   userdata: string;
+  hcloud?: HcloudMachine;
 }
 
 export interface Cluster {

--- a/integration-tests/testdata/cluster.yaml
+++ b/integration-tests/testdata/cluster.yaml
@@ -5,17 +5,19 @@ privateSubnetwork: 10.0.0.0/24
 machines:
   - id: cp1
     type: controlplane
-    serverType: cpx11
     platform: hcloud
     talosInitialVersion: v1.5.0
     talosImage: ghcr.io/siderolabs/installer:v1.5.0
     privateIP: 10.0.0.2
-    datacenter: fsn1
+    hcloud:
+      serverType: cpx11
+      datacenter: fsn1
   - id: worker1
     type: worker
-    serverType: cpx11
     platform: hcloud
     talosInitialVersion: v1.5.0
     talosImage: ghcr.io/siderolabs/installer:v1.5.0
     privateIP: 10.0.0.3
-    datacenter: fsn1
+    hcloud:
+      serverType: cpx11
+      datacenter: fsn1

--- a/integration-tests/testdata/programs/hcloud-go/cluster.yaml
+++ b/integration-tests/testdata/programs/hcloud-go/cluster.yaml
@@ -7,9 +7,10 @@ machines:
     type: init
     platform: hcloud
     talosImage: ghcr.io/siderolabs/installer:v1.11.0
-    serverType: cx22
     privateIP: 10.10.10.5
-    datacenter: fsn1-dc14
+    hcloud:
+      serverType: cx22
+      datacenter: fsn1-dc14
     configPatches:
       - |
         debug: false
@@ -40,9 +41,10 @@ machines:
     type: worker
     platform: hcloud
     talosImage: ghcr.io/siderolabs/installer:v1.11.0
-    serverType: cx22
     privateIP: 10.10.10.3
-    datacenter: fsn1-dc14
+    hcloud:
+      serverType: cx22
+      datacenter: fsn1-dc14
     configPatches:
       - |
         debug: false

--- a/integration-tests/testdata/programs/hcloud-ha-go/main.go
+++ b/integration-tests/testdata/programs/hcloud-ha-go/main.go
@@ -23,36 +23,43 @@ var clu = &cluster.Cluster{
 			Type:       "init",
 			TalosImage: talosImage,
 			Platform:   platform,
-			ServerType: "cx22",
 			PrivateIP:  "10.10.10.5",
+			Hcloud: &cluster.HcloudMachine{
+				ServerType: "cx22",
+			},
 		},
 		{
 			ID:         "controlplane-2",
 			Type:       string(talos.MachineTypesControlplane),
 			Platform:   platform,
 			TalosImage: talosImage,
-
-			ServerType: "cx22",
 			PrivateIP:  "10.10.10.2",
-			//	Datacenter: "fsn1-dc14",
+			Hcloud: &cluster.HcloudMachine{
+				ServerType: "cx22",
+				// Datacenter: "fsn1-dc14",
+			},
 		},
 		{
 			ID:         "controlplane-3",
 			Type:       string(talos.MachineTypesControlplane),
-			ServerType: "cx22",
 			Platform:   platform,
 			TalosImage: talosImage,
 			PrivateIP:  "10.10.10.10",
-			//	Datacenter: "fsn1-dc14",
+			Hcloud: &cluster.HcloudMachine{
+				ServerType: "cx22",
+				// Datacenter: "fsn1-dc14",
+			},
 		},
 		{
 			ID:         "worker-1",
 			Type:       "worker",
 			Platform:   platform,
 			TalosImage: talosImage,
-			ServerType: "cx22",
 			PrivateIP:  "10.10.10.3",
-			//	Datacenter: "fsn1-dc14",
+			Hcloud: &cluster.HcloudMachine{
+				ServerType: "cx22",
+				// Datacenter: "fsn1-dc14",
+			},
 		},
 	},
 }

--- a/integration-tests/testdata/programs/hcloud-js/index.ts
+++ b/integration-tests/testdata/programs/hcloud-js/index.ts
@@ -12,8 +12,10 @@ const cluster: Cluster = {
     {
       id: "controlplane-1",
       type: talos.MachineTypes.Init,
-      serverType: "cax21",
       privateIP: "10.10.10.2",
+      hcloud: {
+        serverType: "cax21",
+      },
       configPatches: [
         JSON.stringify({
           debug: true,

--- a/integration-tests/testdata/programs/hcloud-js/types.ts
+++ b/integration-tests/testdata/programs/hcloud-js/types.ts
@@ -9,17 +9,21 @@ export type Cluster = {
   machines: ClusterMachine[];
 };
 
+export type HcloudMachine = {
+  serverType: string;
+  datacenter?: string;
+};
+
 export type ClusterMachine = {
   id: string;
   type: talos.MachineTypes;
-  serverType: string;
   privateIP: string;
   talosImage?: string;
-  datacenter?: string;
   platform?: string;
   talosInitialVersion?: string;
   configPatches?: string[];
   userdata?: string;
+  hcloud?: HcloudMachine;
 };
 
 export type DeployedServer = {


### PR DESCRIPTION
## Summary
- split hcloud-specific machine configuration into a dedicated struct across the Go, Python, and TypeScript specs
- refactor the hcloud integration provider to validate machines via the new struct and centralize server creation
- update test fixtures and helpers to consume the nested hcloud configuration and derive image metadata per machine

## Testing
- go test ./integration-tests/pkg/...


------
https://chatgpt.com/codex/tasks/task_e_68c98583a6f4832fa316afe72326faf6